### PR TITLE
Modifié m06.html

### DIFF
--- a/lines/m06.html
+++ b/lines/m06.html
@@ -39,7 +39,7 @@
 			</tr>
 			<tr>
 				<td class="title">Matériel</td>
-				<td>MP 73 (20 rames au 6 mars 2025)<br>MP 89 CC (24 rames au 10 mars 2025)</td>
+				<td>MP 73 (18 rames au 12 avril 2025)<br>MP 89 CC (26 rames au 02 mai 2025)</td>
 			</tr>
       		<tr>
         		<td class="title">Conduite (système)</td>


### PR DESCRIPTION
Mise à jour du nombre de rames MP 73 et MP 89 CC affectées à la ligne 6 (source : Wikipédia).